### PR TITLE
Update to Terraform 0.10.2.

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -6,7 +6,7 @@ LABEL \
       vendor="sortuniq"            \
       description="common tools to run terraform in or for aws"
 
-ENV TERRAFORM_VERSION=0.9.11
+ENV TERRAFORM_VERSION=0.10.2
 
 COPY alpine_build_scripts/* bootstrap.sh /alpine_build_scripts/
 


### PR DESCRIPTION
I needed a fix available in the split AWS provider, so I thought it can be useful to bump the TF version.