### PR TITLE
Build fix 0.11.6

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -5,14 +5,15 @@ LABEL \
       name="opsgang/aws_terraform" \
       description="common tools to run terraform in or for aws"
 
-ENV TERRAFORM_VERSION=0.11.3 \
+ENV TERRAFORM_VERSION=0.11.6 \
     PREINSTALLED_PLUGINS=/tf_plugins_cache_dir \
-    PROVIDER_VERSIONS=/provider.versions
+    PROVIDER_VERSIONS=/provider.versions \
+    SCRIPTS_REPO="https://github.com/opsgang/alpine_build_scripts"
 
-COPY alpine_build_scripts/* /alpine_build_scripts/
 COPY assets /var/tmp/assets
 
 RUN cp -a /var/tmp/assets/. / \
+    && ( sh -c "ghfetch --repo ${SCRIPTS_REPO} --tag='~>1.0' /alpine_build_scripts" ) \
     && chmod a+x /bootstrap.sh /alpine_build_scripts/* \
     && sh /alpine_build_scripts/install_terraform.sh \
     && bash /alpine_build_scripts/install_tf_providers.sh \

--- a/Dockerfile
+++ b/Dockerfile
@@ -7,8 +7,7 @@ LABEL \
 
 ENV TERRAFORM_VERSION=0.11.6 \
     PREINSTALLED_PLUGINS=/tf_plugins_cache_dir \
-    PROVIDER_VERSIONS=/provider.versions \
-    SCRIPTS_REPO="https://github.com/opsgang/alpine_build_scripts"
+    PROVIDER_VERSIONS=/provider.versions
 
 COPY alpine_build_scripts/* bootstrap.sh /alpine_build_scripts/
 COPY assets /var/tmp/assets

--- a/Dockerfile
+++ b/Dockerfile
@@ -22,6 +22,8 @@ RUN cp -a /var/tmp/assets/. / \
     && cp -a /alpine_build_scripts/install_tf_providers.sh \
         /usr/local/bin/terraform_providers \
     && sh /alpine_build_scripts/install_essentials.sh \
+    && chmod a+rwx /usr/local/bin \
+    && chmod a+rwx /usr/local/bin/terraform \
     && rm -rf /var/cache/apk/* /var/tmp/assets /alpine_build_scripts 2>/dev/null
 
 ENTRYPOINT ["/bootstrap.sh"]

--- a/Dockerfile
+++ b/Dockerfile
@@ -10,10 +10,10 @@ ENV TERRAFORM_VERSION=0.11.6 \
     PROVIDER_VERSIONS=/provider.versions \
     SCRIPTS_REPO="https://github.com/opsgang/alpine_build_scripts"
 
+COPY alpine_build_scripts/* bootstrap.sh /alpine_build_scripts/
 COPY assets /var/tmp/assets
 
 RUN cp -a /var/tmp/assets/. / \
-    && ( sh -c "ghfetch --repo ${SCRIPTS_REPO} --tag='~>1.0' /alpine_build_scripts" ) \
     && chmod a+x /bootstrap.sh /alpine_build_scripts/* \
     && sh /alpine_build_scripts/install_terraform.sh \
     && bash /alpine_build_scripts/install_tf_providers.sh \

--- a/assets/provider.versions
+++ b/assets/provider.versions
@@ -1,4 +1,4 @@
-aws=1.9.0
+aws=1.14.0
 fastly=0.1.4
 local=1.1.0
 null=1.0.0

--- a/bootstrap.sh
+++ b/bootstrap.sh
@@ -1,0 +1,6 @@
+#!/bin/sh
+
+# install new version if specified
+[[ -z "$TERRAFORM_VERSION" ]] || /usr/local/bin/terraform_version $TERRAFORM_VERSION  || exit 1
+
+exec "$@"

--- a/build.sh
+++ b/build.sh
@@ -59,6 +59,18 @@ apk_pkg_version() {
     | grep -Po "(?<=^$pkg-)[^ ]+(?= description:)" | head -n 1
 }
 
+fetch_alpine_build_scripts() {
+    if [[ -d alpine_build_scripts ]]; then
+        echo "INFO: Alpine scripts updating started."
+        cd alpine_build_scripts && git pull && cd ..
+        echo "INFO: Alpine scripts updating finished."
+    else
+        echo "INFO: Alpine scripts repo cloning started."
+        git clone --depth 1 https://github.com/opsgang/alpine_build_scripts
+        echo "INFO: Alpine scripts repo cloning finished."
+    fi
+}
+
 terraform_version() {
     grep -Po '(?<=\bTERRAFORM_VERSION=)[0-9\.]+' Dockerfile
 }
@@ -141,6 +153,8 @@ docker_build(){
 
     labels=$(labels) || return 1
     n=$(img_name) || return 1
+
+    fetch_alpine_build_scripts || 1
 
     echo "INFO: adding these labels:"
     echo "$labels"

--- a/build.sh
+++ b/build.sh
@@ -61,13 +61,9 @@ apk_pkg_version() {
 
 fetch_alpine_build_scripts() {
     if [[ -d alpine_build_scripts ]]; then
-        echo "INFO: Alpine scripts updating started."
         cd alpine_build_scripts && git pull && cd ..
-        echo "INFO: Alpine scripts updating finished."
     else
-        echo "INFO: Alpine scripts repo cloning started."
         git clone --depth 1 https://github.com/opsgang/alpine_build_scripts
-        echo "INFO: Alpine scripts repo cloning finished."
     fi
 }
 
@@ -154,7 +150,9 @@ docker_build(){
     labels=$(labels) || return 1
     n=$(img_name) || return 1
 
+    echo "INFO: fetching the Alpine build scripts…"
     fetch_alpine_build_scripts || 1
+    echo "INFO: fetching the Alpine build scripts… done"
 
     echo "INFO: adding these labels:"
     echo "$labels"

--- a/shippable.yml
+++ b/shippable.yml
@@ -8,7 +8,6 @@ branches:
 env:
   global:
     - IMG="aws_terraform"
-    - SR="https://github.com/opsgang/alpine_build_scripts"
     - JQ="https://github.com/stedolan/jq/releases/download/jq-1.5/jq-linux64"
 
 build:
@@ -18,7 +17,6 @@ build:
       && chmod +x jq-linux64
       && sudo mv jq-linux64 /usr/bin/jq
     - docker pull opsgang/$IMG:stable || true # speed up build layers
-    - git clone $SR --depth 1
     - bash ./build.sh # avoid aufs file-locking with new shell
     - bash ./test.sh
 


### PR DESCRIPTION
Fixes the following:

- The image can be used with other than uid 0, so you can run terraform without sudo requirement to clean up the cached modules and plugins.
- The build was broken, because the alpine_build_scripts are not available in the parent aws_env image any more.
- Updated to the latest 0.11.6