### PR TITLE
Run as unpriv users

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -2,3 +2,4 @@ build.sh
 **/*.pem
 **/*.tmpl
 **/*.swp
+**/.terraform

--- a/Dockerfile
+++ b/Dockerfile
@@ -15,7 +15,6 @@ COPY assets /assets
 RUN chmod a+x /assets/*.sh /assets/usr/local/bin/* \
     && cp -a /assets/. / \
     && chown -R 501:501 /_test/unpriv \
-    && ls -l /_test /provider.versions \
     && apk --no-cache --update add sudo unzip \
     && mkdir ${TERRAFORM_BIN} \
     && chmod a+w /etc/passwd /etc/group /etc/shadow \

--- a/Dockerfile
+++ b/Dockerfile
@@ -5,23 +5,24 @@ LABEL \
       name="opsgang/aws_terraform" \
       description="common tools to run terraform in or for aws"
 
-ENV TERRAFORM_VERSION=0.11.3 \
+ENV TERRAFORM_VERSION=0.11.7 \
+    TERRAFORM_BIN=/tf_bin \
     PREINSTALLED_PLUGINS=/tf_plugins_cache_dir \
     PROVIDER_VERSIONS=/provider.versions
 
-COPY alpine_build_scripts/* /alpine_build_scripts/
-COPY assets /var/tmp/assets
+COPY assets /assets
 
-RUN cp -a /var/tmp/assets/. / \
-    && chmod a+x /bootstrap.sh /alpine_build_scripts/* \
-    && sh /alpine_build_scripts/install_terraform.sh \
-    && bash /alpine_build_scripts/install_tf_providers.sh \
-    && cp -a /alpine_build_scripts/install_terraform.sh \
-        /usr/local/bin/terraform_version \
-    && cp -a /alpine_build_scripts/install_tf_providers.sh \
-        /usr/local/bin/terraform_providers \
-    && sh /alpine_build_scripts/install_essentials.sh \
-    && rm -rf /var/cache/apk/* /var/tmp/assets /alpine_build_scripts 2>/dev/null
+RUN chmod a+x /assets/*.sh /assets/usr/local/bin/* \
+    && cp -a /assets/. / \
+    && chown -R 501:501 /_test/unpriv \
+    && ls -l /_test /provider.versions \
+    && apk --no-cache --update add sudo unzip \
+    && mkdir ${TERRAFORM_BIN} \
+    && chmod a+w /etc/passwd /etc/group /etc/shadow \
+    && echo 'ALL ALL=(ALL) NOPASSWD: SETENV: /change_perms.sh' > /etc/sudoers.d/change_perms \
+    && bash /usr/local/bin/terraform_version \
+    && bash /usr/local/bin/terraform_providers \
+    && rm -rf /var/cache/apk/* /assets 2>/dev/null
 
 ENTRYPOINT ["/bootstrap.sh"]
 

--- a/Dockerfile
+++ b/Dockerfile
@@ -7,7 +7,7 @@ LABEL \
 
 ENV TERRAFORM_VERSION=0.11.7 \
     TERRAFORM_BIN=/tf_bin \
-    PREINSTALLED_PLUGINS=/tf_plugins_cache_dir \
+    PREINSTALLED_PLUGINS=/tf_plugin_cache_dir \
     PROVIDER_VERSIONS=/provider.versions
 
 COPY assets /assets

--- a/README.md
+++ b/README.md
@@ -2,23 +2,21 @@
 [2]: http://docs.aws.amazon.com/cli/latest/reference "use aws apis from cmd line"
 [3]: https://github.com/fugue/credstash "credstash - store and retrieve secrets in aws"
 [4]: https://github.com/opsgang/alpine_build_scripts/blob/master/install_essentials.sh "common GNU tools useful for automation"
+[5]: https://github.com/opsgang/docker_aws_env "opsgang's aws_env docker image"
+
 # docker\_aws\_terraform
 
-_... alpine container with common tools to use Hashicorp's terraform on or for aws_
+_... alpine container with common tools and scripts to use Hashicorp's terraform on or for aws_
 
 > For terraform >=0.10.0, this image also supports a plugins cache dir
 > and is preinstalled with some popular ones to reduce download dependencies
 > at run-time.
 
-## featuring ...
+## features
 
-* [hashicorp's terraform] [1]
+* [hashicorp's terraform][1]
 
-* [aws cli] [2]
-
-* [credstash] [3] (for managing secrets in aws)
-
-* bash, curl, git, make, jq, openssh client [and friends] [4]
+* tools from [opsgang/aws\_env][5] including, [aws cli][2], [credstash][3] [and more][4]
 
 ## docker tags
 
@@ -44,7 +42,6 @@ Newer versions will also include more recent versions of alpine and tools.
 ```bash
 git clone https://github.com/opsgang/docker_aws_terraform.git
 cd docker_aws_terraform
-git clone https://github.com/opsgang/alpine_build_scripts
 ./build.sh # adds custom labels to image
 ./test.sh
 ```
@@ -65,11 +62,11 @@ docker run -i --rm -v /my/tf/dir:/workspace -w /workspace \
     opsgang/aws_terraform:stable <some cmds to run>
 
 # To use a plugins cache dir on the host (if terraform version >=0.10.7)
-# mount it to /tf_plugins_cache_dir and set TF_PLUGIN_CACHE_DIR var:
+# mount it to /tf_plugins_cache_dir and set TF_PLUGINS_CACHE_DIR var:
 #
 docker run -i --rm -v /my/tf/dir:/workspace -w /workspace \
     -v /my/cache/dir:/tf_plugins_cache_dir \
-    -e TF_PLUGIN_CACHE_DIR=/tf_plugins_cache_dir \
+    -e TF_PLUGINS_CACHE_DIR=/tf_plugins_cache_dir \
     opsgang/aws_terraform:stable <some cmds to run>
 ```
 

--- a/README.md
+++ b/README.md
@@ -8,9 +8,12 @@
 
 _... alpine container with common tools and scripts to use Hashicorp's terraform on or for aws_
 
-> For terraform >=0.10.0, this image also supports a plugins cache dir
-> and is preinstalled with some popular ones to reduce download dependencies
-> at run-time.
+> Use different versions of terraform. Use host volumes to cache plugins and
+> terraform binaries for faster run-time.
+
+> This image is always preloaded with the latest terraform at time it was built.
+> It is also preinstalled with some popular plugins to reduce download dependencies
+> at run-time. See [assets/provider.versions](assets/provider.versions)
 
 ## features
 
@@ -77,6 +80,13 @@ docker run -i --rm -v /my/tf/dir:/workspace -w /workspace \
 # e.g. to use 0.9.8
 #
 docker run --rm -e TERRAFORM_VERSION=0.9.8 -i opsgang/aws_terraform:stable <some cmds to run>
+
+# To 'cache' the downloaded terraforms on a host volume,
+# mount your dir to /tf_bin
+docker run --rm -i \
+    -e TERRAFORM_VERSION=0.11.7 \
+    -v /my/tf/binaries:/tf_bin \
+    opsgang/aws_terraform:stable <some cmds to run>
 ```
 
 ```bash

--- a/README.md
+++ b/README.md
@@ -65,11 +65,11 @@ docker run -i --rm -v /my/tf/dir:/workspace -w /workspace \
     opsgang/aws_terraform:stable <some cmds to run>
 
 # To use a plugins cache dir on the host (if terraform version >=0.10.7)
-# mount it to /tf_plugins_cache_dir and set TF_PLUGINS_CACHE_DIR var:
+# mount it to /tf_plugin_cache_dir and set TF_PLUGIN_CACHE_DIR var:
 #
 docker run -i --rm -v /my/tf/dir:/workspace -w /workspace \
-    -v /my/cache/dir:/tf_plugins_cache_dir \
-    -e TF_PLUGINS_CACHE_DIR=/tf_plugins_cache_dir \
+    -v /my/cache/dir:/tf_plugin_cache_dir \
+    -e TF_PLUGIN_CACHE_DIR=/tf_plugin_cache_dir \
     opsgang/aws_terraform:stable <some cmds to run>
 ```
 

--- a/README.md
+++ b/README.md
@@ -8,6 +8,8 @@
 
 _... alpine container with common tools and scripts to use Hashicorp's terraform on or for aws_
 
+[![Run Status](https://api.shippable.com/projects/589913a86ee43c0f00b47cb6/badge?branch=master)](https://app.shippable.com/projects/589913a86ee43c0f00b47cb6)
+
 > Use different versions of terraform. Use host volumes to cache plugins and
 > terraform binaries for faster run-time.
 
@@ -40,8 +42,6 @@ _... alpine container with common tools and scripts to use Hashicorp's terraform
 * tools from [opsgang/aws\_env][5] including, [aws cli][2], [credstash][3] [and more][4]
 
 ## docker tags
-
-[![Run Status](https://api.shippable.com/projects/589913a86ee43c0f00b47cb6/badge?branch=master)](https://app.shippable.com/projects/589913a86ee43c0f00b47cb6)
 
 **tags on master are built at shippable.com and available from dockerhub**
 
@@ -89,7 +89,8 @@ you download won't be there once the container is killed.
 >
 
 Bear in mind, the downloaded assets are only suitable for linux amd64
-so don't go trying them with terraform on your beloved macbook.
+so don't go trying to use the cached contents on your beloved macbook
+outside of the container.
 
 The minor caveat is that the container's preinstalled binaries
 and plugins are not available if you mount your own dirs.

--- a/assets/_test/unpriv/backend.tf
+++ b/assets/_test/unpriv/backend.tf
@@ -1,0 +1,6 @@
+# vim: et sr sw=2 ts=2 smartindent syntax=terraform:
+terraform {
+  backend "local" {
+    path="/var/tmp/tfstate"
+  }
+}

--- a/assets/_test/unpriv/main.tf
+++ b/assets/_test/unpriv/main.tf
@@ -1,0 +1,13 @@
+# vim: et sr sw=2 ts=2 smartindent:
+variable "ts" {}
+
+resource "null_resource" "foo" {
+  triggers {
+    bar = "${var.ts}"
+  }
+}
+
+module "null" "bar" {
+  source = "./module"
+  foo    = "${var.ts}"
+}

--- a/assets/_test/unpriv/module/main.tf
+++ b/assets/_test/unpriv/module/main.tf
@@ -1,0 +1,8 @@
+# vim: et sr sw=2 ts=2 smartindent syntax=terraform:
+variable "foo" {}
+
+resource "null_resource" "bar" {
+  triggers {
+    bar = "${var.foo}"
+  }
+}

--- a/assets/bootstrap.sh
+++ b/assets/bootstrap.sh
@@ -26,14 +26,35 @@ need_providers_copied () {
 
 # return 0 if user has specified either:
 # * plugin_cache_dir in $HOME/.terraformrc
-# * passed $TF_PLUGIN_CACHE_DIR to container
+# * passed $TF_PLUGINS_CACHE_DIR to container
 user_passed_cache_dir() {
     local f=$HOME/.terraformrc
-    [[ ! -z "$TF_PLUGIN_CACHE_DIR" ]] && return 0
+    [[ ! -z "$TF_PLUGINS_CACHE_DIR" ]] && return 0
     [[ -r $f ]] && grep -P '^\s*plugin_cache_dir\s*=' $f >/dev/null && return 0
 
     return 1
 }
+
+# set up /usr/local/bin for this user
+uid=$(id -u)
+gid=$(id -g)
+
+if ! getent group $gid >/dev/null 2>&1
+then
+    echo "INFO: creating group $gid for sudo"
+    echo "$gid:x:$gid:$gid" >>/etc/group
+fi
+
+if ! getent passwd $uid >/dev/null 2>&1
+then
+    echo "INFO: creating user $uid for sudo"
+    echo "$uid:x:$uid:$gid:$uid:/:/bin/ash" >>/etc/passwd
+fi
+
+sudo -E /change_perms.sh $uid $gid || exit 1
+
+# Add path to dir containing terraform binary to PATH
+export PATH="$TERRAFORM_BIN:$PATH"
 
 # install new version if specified
 [[ -z "$TERRAFORM_VERSION" ]] || /usr/local/bin/terraform_version $TERRAFORM_VERSION  || exit 1
@@ -59,9 +80,9 @@ then
     export -f terraform
 
 else
-    # ... set TF_PLUGIN_CACHE_DIR if not in .terraformrc or already passed by user
+    # ... set TF_PLUGINS_CACHE_DIR if not in .terraformrc or already passed by user
     # (Note that cache dir will be ignored unless terraform >= v0.10.7)
-    user_passed_cache_dir || export TF_PLUGIN_CACHE_DIR="$PREINSTALLED_PLUGINS"
+    user_passed_cache_dir || export TF_PLUGINS_CACHE_DIR="$PREINSTALLED_PLUGINS"
 fi
 
 unset _TV need_providers_copied

--- a/assets/bootstrap.sh
+++ b/assets/bootstrap.sh
@@ -26,10 +26,10 @@ need_providers_copied () {
 
 # return 0 if user has specified either:
 # * plugin_cache_dir in $HOME/.terraformrc
-# * passed $TF_PLUGINS_CACHE_DIR to container
+# * passed $TF_PLUGIN_CACHE_DIR to container
 user_passed_cache_dir() {
     local f=$HOME/.terraformrc
-    [[ ! -z "$TF_PLUGINS_CACHE_DIR" ]] && return 0
+    [[ ! -z "$TF_PLUGIN_CACHE_DIR" ]] && return 0
     [[ -r $f ]] && grep -P '^\s*plugin_cache_dir\s*=' $f >/dev/null && return 0
 
     return 1
@@ -80,9 +80,12 @@ then
     export -f terraform
 
 else
-    # ... set TF_PLUGINS_CACHE_DIR if not in .terraformrc or already passed by user
+    # ... set TF_PLUGIN_CACHE_DIR if not in .terraformrc or already passed by user
     # (Note that cache dir will be ignored unless terraform >= v0.10.7)
-    user_passed_cache_dir || export TF_PLUGINS_CACHE_DIR="$PREINSTALLED_PLUGINS"
+    if ! user_passed_cache_dir
+    then
+        export TF_PLUGIN_CACHE_DIR="$PREINSTALLED_PLUGINS"
+    fi
 fi
 
 unset _TV need_providers_copied

--- a/assets/change_perms.sh
+++ b/assets/change_perms.sh
@@ -1,0 +1,30 @@
+#!/bin/bash
+#
+# When running aws_terraform as a different user under docker (e.g --user)
+# we need to be able to create and delete files under the bin dir for terraform
+# and the cache dir.
+#
+# This script (to be run via sudo) will change perms of the critical dirs.
+# based on current user and group id
+#
+
+uid=$1
+gid=$2
+
+[[ $uid -eq 0 ]] && exit 0
+
+BIN_DIR="${TERRAFORM_BIN}"
+TF_PLUGINS_CACHE_DIR="${TF_PLUGINS_CACHE_DIR:-$PREINSTALLED_PLUGINS}"
+
+if [[ "$TF_PLUGINS_CACHE_DIR" =~ /sbin ]] || [[ "$BIN_DIR" =~ /sbin ]]; then
+    echo "ERROR $0: really? sbin? Not happening"
+    exit 1
+fi
+
+echo "INFO $0: changing perms of bin dir $BIN_DIR and cache dir for uid:gid $uid:$gid."
+if [[ ! -d $BIN_DIR ]] || [[ ! -w $BIN_DIR ]]; then
+    echo "ERROR $0: $BIN_DIR is not a writable dir"
+    exit 1
+fi
+
+chown -R $uid:$gid $BIN_DIR $TF_PLUGINS_CACHE_DIR

--- a/assets/change_perms.sh
+++ b/assets/change_perms.sh
@@ -14,9 +14,9 @@ gid=$2
 [[ $uid -eq 0 ]] && exit 0
 
 BIN_DIR="${TERRAFORM_BIN}"
-TF_PLUGINS_CACHE_DIR="${TF_PLUGINS_CACHE_DIR:-$PREINSTALLED_PLUGINS}"
+TF_PLUGIN_CACHE_DIR="${TF_PLUGIN_CACHE_DIR:-$PREINSTALLED_PLUGINS}"
 
-if [[ "$TF_PLUGINS_CACHE_DIR" =~ /sbin ]] || [[ "$BIN_DIR" =~ /sbin ]]; then
+if [[ "$TF_PLUGIN_CACHE_DIR" =~ /sbin ]] || [[ "$BIN_DIR" =~ /sbin ]]; then
     echo "ERROR $0: really? sbin? Not happening"
     exit 1
 fi
@@ -27,4 +27,4 @@ if [[ ! -d $BIN_DIR ]] || [[ ! -w $BIN_DIR ]]; then
     exit 1
 fi
 
-chown -R $uid:$gid $BIN_DIR $TF_PLUGINS_CACHE_DIR
+chown -R $uid:$gid $BIN_DIR $TF_PLUGIN_CACHE_DIR

--- a/assets/provider.versions
+++ b/assets/provider.versions
@@ -1,4 +1,4 @@
-aws=1.9.0
+aws=1.14.0
 fastly=0.1.4
 local=1.1.0
 null=1.0.0

--- a/assets/usr/local/bin/terraform_providers
+++ b/assets/usr/local/bin/terraform_providers
@@ -1,0 +1,82 @@
+#!/bin/bash
+# vim: et smartindent sr sw=4 ts=4:
+# For versions of terraform >= 0.10, the provider has to be installed
+# separately.
+#
+PREINSTALLED_PLUGINS=${PREINSTALLED_PLUGINS:-/tf_providers}
+PROVIDER_VERSIONS=${PROVIDER_VERSIONS:-/provider.versions}
+export PATH="${TERRAFORM_BIN}:$PATH"
+
+need_providers() {
+    # only interested if version more than or equal to 0.10.0
+    local valid="0.10.0" tv=""
+    tv=$(terraform --version | grep -Po '(?<=Terraform v)[\d\.]+')
+    if [[ $? -ne 0 ]] || [[ -z "$tv" ]]; then
+        echo "ERROR $0: could not determine terraform version from terraform --version" >&2
+        exit 1 # deliberately short-circuit, as return val used for truth
+    fi
+
+    # list versions in ascending order and ensure our current version not first listed.
+    if [[ $(echo -e "$tv\n$valid" | sort -V | head -n 1) == "$tv" ]]; then
+        echo "WARN $0: getting providers only needed with terraform versions >= $valid" >&2
+        echo "WARN $0: ... currently using terraform version $tv" >&2
+        return 1
+    else
+        return 0
+    fi
+
+}
+
+tf_provider_code() {
+    local pn="$1" # provider name clause
+    local pv="$2" # provider version clause
+
+    if [[ -z "$pv" ]]; then
+        echo "ERROR $0: tf_provider_code(): must pass provider name and version" >&2
+        return 1
+    fi
+
+    cat << EOF
+provider "$pn" {
+    version = "$pv"
+}
+EOF
+}
+
+tf_main() {
+    local f="" pn="" pv=""
+    while IFS= read -r line ; do
+        pn=$(echo $line | grep -Po '^[^=]+' | sed -e 's/^ *//' -e 's/ $//')
+        pv=$(
+            echo $line \
+            | grep -Po '(?<==)[^=]+' \
+            | sed -e 's/"//g' -e "s/'//g" -e 's/^ *//' -e 's/ $//'
+        )
+        f="$f$(tf_provider_code "$pn" "$pv")"
+    done < <(cat $PROVIDER_VERSIONS | grep -v '^#')
+    echo "$f"
+}
+
+echo "INFO $0: ... checking we need to get providers (if terraform >= 0.10.x)"
+need_providers || exit 0 # exit-on-runtime-err within func
+
+rm -rf $PREINSTALLED_PLUGINS ; mkdir -p $PREINSTALLED_PLUGINS
+
+if [[ ! -r $PROVIDER_VERSIONS ]]; then
+    echo "ERROR $0: ... $PROVIDER_VERSIONS not readable" >&2
+    exit 1
+fi
+
+echo "INFO $0: ... generating main.tf to download providers"
+f=$(tf_main)
+
+(
+    cd $PREINSTALLED_PLUGINS
+    echo "$f">main.tf
+    terraform init || exit 1
+    mv .terraform/plugins/* .
+    rm main.tf *.tfstate *.tfstate.backup 2>/dev/null
+    rm -rf .terraform 2>/dev/null
+    find . -name 'lock.json' -exec rm {} \; || true
+) || exit 1
+

--- a/assets/usr/local/bin/terraform_version
+++ b/assets/usr/local/bin/terraform_version
@@ -1,0 +1,150 @@
+#!/bin/bash
+# vim: et smartindent sr sw=4 ts=4:
+#
+# For running on Alpine.
+#
+# CAVEAT: script only works with single binary versions
+# i.e versions greater than $XVER
+#
+# Use to install multiple versions of terraform.
+# and switch between them.
+#
+# /usr/local/bin/terraform is symlinked to desired
+# versioned one under /usr/local/bin.
+#
+# Also installs vim plugin if pathogen detected.
+#
+APP=terraform
+XVER=0.6.16
+VER=${1:-$TERRAFORM_VERSION}
+BIN="${TERRAFORM_BIN:-/usr/local/bin}"
+ZIP="$BIN/${APP}-$VER.zip"
+BUILD_PKGS=""
+export PATH="$TERRAFORM_BIN:$PATH"
+
+APK_TMP="/var/cache/apk"
+
+if [[ "$VER" =~ -?(list|show)$ ]]; then
+
+    # ... if we have gnu sort, we can order by semantic version
+    # (default busybox sort does not support -V)
+    sort_opts="-rV"
+    ! apk info 2>/dev/null | grep "^sort$" >/dev/null 2>&1 && sort_opts=""
+
+    echo "Versions available under $BIN:"
+    if [[ -L $BIN/${APP} ]]; then
+        echo "using: $(ls -l $BIN/${APP} | sed -e 's/.* \([^ ]\+ -> [^ ]\+\)/\1/')"
+    elif [[ -x $BIN/${APP} ]]; then
+        echo "using: $($BIN/${APP} --version)"
+    fi
+    f=$(
+        set -o pipefail ;
+        ls -1 $BIN/${APP}-* 2>/dev/null \
+        | sed -e 's/.*${APP}-//' \
+        | sort $sort_opts \
+        || echo "No terraform binaries found."
+    )
+    echo "$f" && exit 0
+fi
+
+[[ -z "$VER" ]] && echo "ERROR $0: must pass a semantic version!" && exit 1
+
+if ! [[ "$VER" =~ ^[0-9]+\.[0-9]+\.[0-9]+$ ]] ; then
+    echo "ERROR $0: "$VER" is not a semantic version!"
+    exit 1
+fi
+
+if [[ $(echo -e "$VER\n$XVER" | sort -V | head -n 1) == "$VER" ]]; then
+    echo "ERROR $0: script only works with versions greater than $XVER" >&2
+    exit 1
+fi
+
+if [[ -f $BIN/${APP} ]]; then
+    if [[ -L $BIN/${APP} ]]; then
+        if ! rm $BIN/${APP}
+        then
+            echo "ERROR $0: ... could not delete symlink $BIN/${APP}"
+            exit 1
+        fi
+    elif [[ -x $BIN/${APP} ]]; then
+        OLDVER=$($BIN/${APP} --version | grep '^Terraform v' | sed -e 's/.* v\(.*\)$/\1/')
+        if ! mv $BIN/${APP} $BIN/${APP}-$OLDVER
+        then
+            echo "ERROR $0: ... could not move existing to $BIN/${APP}-$OLDVER"
+            exit 1
+        fi
+    else
+        echo "ERROR $0: ... $BIN/${APP} is not a bin or symlink to bin"
+        exit 1
+    fi
+fi
+
+if [[ ! -x $BIN/${APP}-$VER ]]; then
+    BASE_URI="https://releases.hashicorp.com/${APP}"
+    DOWNLOAD_URI="$BASE_URI/$VER/${APP}_${VER}_linux_amd64.zip"
+
+    REQ_PKGS="wget unzip ca-certificates"
+    for p in $REQ_PKGS; do
+        if ! apk info 2>/dev/null | grep "^${p}$" >/dev/null 2>&1
+        then
+            BUILD_PKGS="$BUILD_PKGS $p"
+        fi
+    done
+
+    if [[ ! -z $(echo "$BUILD_PKGS" | sed -e 's/ //g') ]] ; then
+        echo "ERROR $0: apk pkgs $BUILD_PKGS required. Please install these first."
+        exit 1
+    fi
+
+    echo "INFO $0: ... downloading ${APP} $VER"
+    if ! wget -q -T 60 -O $ZIP $DOWNLOAD_URI
+    then
+        echo "ERROR $0: could not download $VER from $DOWNLOAD_URI"
+        echo "ERROR $0: ... are you sure it exists?"
+        rm $ZIP >/dev/null 2>&1
+        exit 1
+    fi
+    if ! unzip -p $ZIP | cat >$BIN/${APP}-$VER
+    then
+        echo "ERROR $0: could not extract ${APP} from zip"
+        exit 1
+    fi
+    chmod a+x $BIN/${APP}-$VER
+    rm -f $ZIP
+else
+    echo "INFO $0: ... $BIN/${APP}-$VER available ."
+fi
+
+echo "INFO $0: ... pointing $BIN/${APP} to $VER"
+if ! ln -s $BIN/${APP}-$VER $BIN/${APP}
+then
+    echo "ERROR $0: could not repoint $BIN/${APP}"
+    exit 1
+fi
+
+if ${APP} --version | grep "v${VER}$" 2>/dev/null
+then
+    echo "INFO $0: installed ${APP} $VER successfully"
+else
+    echo "INFO $0: failed to install"
+    exit 1
+fi
+
+# ... install vim plugin if appropriate
+if [[ -w /etc/vim/bundle ]] && [[ ! -d /etc/vim/bundle/vim-${APP} ]]; then
+    echo "INFO $0: will try to install vim ${APP} plugin"
+    if ! apk info 2>/dev/null | grep '^git$' >/dev/null 2>&1
+    then
+        echo "INFO $0: please apk-add 'git' if you want the terraform vim plugin."
+    else
+        (
+            cd /etc/vim/bundle
+            git clone https://github.com/hashivim/vim-${APP}.git
+            rm -rf vim-${APP}/.git
+        )
+    fi
+fi
+
+rm -rf $APK_TMP/* >/dev/null 2>&1
+
+exit 0

--- a/shippable.yml
+++ b/shippable.yml
@@ -9,12 +9,12 @@ env:
 build:
 
   pre_ci_boot:
-    options: -v /tf/tf_bin:/tf_bin -v /tf/tf_plugins_cache_dir:/tf_plugins_cache_dir
+    options: -v /tf_bin -v /tf_plugin_cache_dir
 
   ci:
     - curl -O -L $JQ && chmod +x jq-linux64 && sudo mv jq-linux64 /usr/bin/jq
     - docker pull opsgang/$IMG:stable || true # speed up build layers
-    - mkdir -p /tf/tf_bin /tf/tf_plugins_cache_dir
+    - mkdir /tf_bin /tf_plugin_cache_dir || true
     - bash ./build.sh # avoid aufs file-locking with new shell
     - bash ./test.sh
 

--- a/shippable.yml
+++ b/shippable.yml
@@ -1,29 +1,25 @@
 # vim: et sr sw=2 ts=2 smartindent:
 language: none
 
-branches:
-  only:
-    - master
-
 env:
   global:
     - IMG="aws_terraform"
-    - SR="https://github.com/opsgang/alpine_build_scripts"
     - JQ="https://github.com/stedolan/jq/releases/download/jq-1.5/jq-linux64"
 
 build:
 
+  pre_ci_boot:
+    options: -v /tf/tf_bin:/tf_bin -v /tf/tf_plugins_cache_dir:/tf_plugins_cache_dir
+
   ci:
-    - curl -O -L $JQ
-      && chmod +x jq-linux64
-      && sudo mv jq-linux64 /usr/bin/jq
+    - curl -O -L $JQ && chmod +x jq-linux64 && sudo mv jq-linux64 /usr/bin/jq
     - docker pull opsgang/$IMG:stable || true # speed up build layers
-    - git clone $SR --depth 1
+    - mkdir -p /tf/tf_bin /tf/tf_plugins_cache_dir
     - bash ./build.sh # avoid aufs file-locking with new shell
     - bash ./test.sh
 
   on_success:
-    - if [[ "$BRANCH" == "master" ]] && [[ "$IS_PULL_REQUEST" != "true" ]]; then
+    - if [[ "$IS_GIT_TAG" == "true" ]] || [[ "$IS_RELEASE" == "true" ]]; then
         a=$(docker inspect opsgang/$IMG:candidate | jq -r '.[].Config.Labels') ;
         v=$(echo $a | jq -r '.version') ;
         gt=$(echo $a | jq -r '."opsgang.build_git_tag"') ;
@@ -41,17 +37,11 @@ integrations:
   hub:
     - integrationName: opsgang_dockerhubreg
       type: dockerRegistryLogin
-      branches:
-        only:
-          - master
 
   notifications:
     - integrationName: opsgang_slack_delivery
       type: slack
       recipients: "#delivery"
-      branches:
-        only:
-          - master
       on_success: always
       on_failure: always
       on_pull_request: never

--- a/test.sh
+++ b/test.sh
@@ -12,13 +12,19 @@ vol_str_for_caches() {
 
 img=opsgang/${IMG:-aws_terraform}:candidate
 _c=test_tf
-cmd="terraform init -input=false ; terraform apply -input=false -auto-approve"
+cmd="sleep 3 ; terraform init -input=false ; terraform apply -input=false -auto-approve"
 
 # ... used in tests for cache dirs if not running in shippable.
 LOCAL_CACHE_CONTAINER=tf_cache_dirs
 tfcd=/var/tmp/tf_plugins_cache_dir
 tfbin=/var/tmp/tf_bin 
+
+docker info
 if [[ -z "$SHIPPABLE_CONTAINER_NAME" ]]; then
+    echo "INFO $0: running local container to act as mounted vols"
+    echo "INFO $0: we do this, because locally we might run the build"
+    echo "INFO $0: within another container ..."
+
     docker run -d --name $LOCAL_CACHE_CONTAINER \
         -v $tfcd:/tf_plugins_cache_dir \
         -v $tfbin:/tf_bin \
@@ -175,6 +181,7 @@ fi
     docker rm -f $_c 2>/dev/null
 
     if [[ -z "$SHIPPABLE_CONTAINER_NAME" ]]; then
+        # e.g when running locally
         rm -rf $tfcd
         docker cp -a $LOCAL_CACHE_CONTAINER:/tf_bin /var/tmp
         docker cp -a $LOCAL_CACHE_CONTAINER:/tf_plugins_cache_dir /var/tmp

--- a/test.sh
+++ b/test.sh
@@ -2,7 +2,7 @@
 # vim: et sr sw=4 ts=4 smartindent:
 
 # When running tests locally, we need to mount some
-# dirs from the host for /tf_bin and /tf_plugins_cache_dir.
+# dirs from the host for /tf_bin and /tf_plugin_cache_dir.
 #
 # In shippable, we use pre_ci_boot options to do the same.
 # and use a different mount arg for docker run.
@@ -10,23 +10,24 @@ vol_str_for_caches() {
     echo --volumes-from ${SHIPPABLE_CONTAINER_NAME:-$LOCAL_CACHE_CONTAINER}
 }
 
+rc=0
+
 img=opsgang/${IMG:-aws_terraform}:candidate
 _c=test_tf
-cmd="sleep 3 ; terraform init -input=false ; terraform apply -input=false -auto-approve"
+cmd='sleep 3 ; terraform init -input=false ; terraform apply -input=false -auto-approve'
 
 # ... used in tests for cache dirs if not running in shippable.
 LOCAL_CACHE_CONTAINER=tf_cache_dirs
-tfcd=/var/tmp/tf_plugins_cache_dir
+tfcd=/var/tmp/tf_plugin_cache_dir
 tfbin=/var/tmp/tf_bin 
 
-docker info
 if [[ -z "$SHIPPABLE_CONTAINER_NAME" ]]; then
     echo "INFO $0: running local container to act as mounted vols"
     echo "INFO $0: we do this, because locally we might run the build"
     echo "INFO $0: within another container ..."
 
     docker run -d --name $LOCAL_CACHE_CONTAINER \
-        -v $tfcd:/tf_plugins_cache_dir \
+        -v $tfcd:/tf_plugin_cache_dir \
         -v $tfbin:/tf_bin \
         alpine:3.7 /bin/sh -c 'while true; do sleep 1000; done'
 fi
@@ -37,8 +38,8 @@ fi
     var="export TF_VAR_ts=$test_name"
     exp='Apply complete! Resources: 2 added, 0 changed, 0 destroyed.'
 
-    echo "INFO $0: test $test_name"
-    echo "INFO $0: ... should use preloaded terraform version"
+    echo "INFO $0: $test_name"
+    echo "INFO $0: $test_name ... should use preloaded terraform version"
 
     docker rm -f $_c 2>/dev/null || true
     o=$(
@@ -47,11 +48,11 @@ fi
             $img /bin/bash -c "$var ; $cmd"
     )
     if [[ $? -ne 0 ]] || [[ ! $(echo "$o" | grep "$exp") ]]; then
-        echo "ERROR $0: failure"
+        echo "ERROR $0: $test_name failure"
         echo "$o"
         rc=1
     else
-        echo "INFO $0:   (passed)"
+        echo "INFO $0: $test_name   (passed)"
     fi
     docker rm -f $_c 2>/dev/null || true
     rm -rf _test/.terraform _test/default/.terraform
@@ -65,8 +66,8 @@ fi
     v=0.10.6
     exp_v='Terraform v0\.10\.6$'
 
-    echo "INFO $0: test $test_name"
-    echo "INFO $0: ... using older terraform which needs plugins copied from cache"
+    echo "INFO $0: $test_name"
+    echo "INFO $0: $test_name ... using older terraform which needs plugins copied from cache"
 
     docker rm -f $_c 2>/dev/null || true
     o=$(
@@ -76,11 +77,11 @@ fi
             $img /bin/bash -c "$var ; $cmd"
     )
     if [[ $? -ne 0 ]] || [[ ! $(echo "$o" | grep "$exp") ]] || [[ ! $(echo "$o" | grep -P "$exp_v") ]] ; then
-        echo "ERROR $0: failure"
+        echo "ERROR $0: $test_name failure"
         echo "$o"
         rc=1
     else
-        echo "INFO $0:   (passed)"
+        echo "INFO $0: $test_name   (passed)"
     fi
     docker rm -f $_c 2>/dev/null || true
     exit $rc
@@ -92,11 +93,13 @@ fi
     var="export TF_VAR_ts=$test_name"
     exp='Apply complete! Resources: 2 added, 0 changed, 0 destroyed.'
 
-    echo "INFO $0: test $test_name"
-    echo "INFO $0: ... trying non-root users with docker run --user "
+    echo "INFO $0: $test_name"
+    echo "INFO $0: $test_name ... trying non-root users with docker run --user "
 
-    for uid_gid in 501:501 666:999; do
+    for uid_gid in 501:501 0:0 501:501; do
 
+    echo "INFO $0: $test_name ... trying $uid_gid"
+        _c=$c_$(date '+%Y%m%d%H%M%S')
         docker rm -f $_c 2>/dev/null || true
         o=$(
             docker run --rm --name $_c \
@@ -105,11 +108,11 @@ fi
                 $img /bin/bash -c "$var ; $cmd"
         )
         if [[ $? -ne 0 ]] || [[ ! $(echo "$o" | grep "$exp") ]]; then
-            echo "ERROR $0: failure"
+            echo "ERROR $0: $test_name failure"
             echo "$o"
             rc=1
         else
-            echo "INFO $0:   (uid:gid[$uid_gid]: passed)"
+            echo "INFO $0: $test_name    (uid:gid[$uid_gid]: passed)"
         fi
         docker rm -f $_c 2>/dev/null || true
     done
@@ -122,53 +125,53 @@ fi
     rc=0
     test_name="test-mounted-tf-dirs"
     var="export TF_VAR_ts=$test_name"
-    exp='.*/tf_bin/terraform-[\d\.]+ .*/tf_plugins_cache_dir/linux_amd64/terraform-provider-null_v'
+    exp='.*/tf_bin/terraform-[\d\.]+ .*/tf_plugin_cache_dir/linux_amd64/terraform-provider-null_v'
 
     
 
-    echo "INFO $0: test $test_name"
-    echo "INFO $0: ... trying with mounted cache and tf_bin dirs"
+    echo "INFO $0: $test_name"
+    echo "INFO $0: $test_name ... trying with mounted cache and tf_bin dirs as root user (default)"
 
     docker rm -f $_c 2>/dev/null
 
     docker run --rm --name $_c \
         $(vol_str_for_caches) \
         -w /_test/default \
-        $img /bin/bash -c "$var ; $cmd" || exit 1
+        $img /bin/bash -c "$var ; $cmd" >/dev/null || exit 1
 
     docker rm -f $_c 2>/dev/null
 
     if [[ -z "$SHIPPABLE_CONTAINER_NAME" ]]; then
-        rm -rf $tfcd
+        rm -rf $tfcd $tf_bin ; 
         docker cp -a $LOCAL_CACHE_CONTAINER:/tf_bin /var/tmp
-        docker cp -a $LOCAL_CACHE_CONTAINER:/tf_plugins_cache_dir /var/tmp
-        o=$(find /var/tmp/tf_bin /var/tmp/tf_plugins_cache_dir -type f | sort)
+        docker cp -a $LOCAL_CACHE_CONTAINER:/tf_plugin_cache_dir /var/tmp
+        o="$(find /var/tmp/tf_bin /var/tmp/tf_plugin_cache_dir -type f | sort)"
     else
-        o=$(find /tf_bin /tf_plugins_cache_dir -type f | sort)
+        o="$(find /tf_bin /tf_plugin_cache_dir -type f | sort)"
     fi
 
     if ! echo $o | grep -P "$exp" >/dev/null
     then
-        echo "ERROR $0: failure."
+        echo "ERROR $0: $test_name failed to find expected files."
         echo -e "... files in mounted vols:\n$o"
         rc=1
     else
-        echo "INFO $0:   (passed)"
+        echo "INFO $0: $test_name   (passed)"
     fi
 
     exit $rc
-)
+) || rc=1
 
 (
     rc=0
     test_name="test-mounted-tf-dirs-from-root-to-unpriv"
     var="export TF_VAR_ts=$test_name"
-    exp='.*/tf_bin/terraform-[\d\.]+ .*/tf_plugins_cache_dir/linux_amd64/terraform-provider-null_v'
+    exp='.*/tf_bin/terraform-[\d\.]+ .*/tf_plugin_cache_dir/linux_amd64/terraform-provider-null_v'
 
     
 
-    echo "INFO $0: test $test_name"
-    echo "INFO $0: ... trying with mounted cache and tf_bin dirs as unpriv user with root-owned content"
+    echo "INFO $0: $test_name"
+    echo "INFO $0: $test_name ... trying with mounted cache and tf_bin dirs as unpriv user with root-owned content"
 
     docker rm -f $_c 2>/dev/null
 
@@ -176,7 +179,7 @@ fi
         $(vol_str_for_caches) \
         --user 501:501 \
         -w /_test/unpriv \
-        $img /bin/bash -c "$var ; $cmd" || exit 1
+        $img /bin/bash -c "$var ; $cmd" >/dev/null || exit 1
 
     docker rm -f $_c 2>/dev/null
 
@@ -184,23 +187,23 @@ fi
         # e.g when running locally
         rm -rf $tfcd
         docker cp -a $LOCAL_CACHE_CONTAINER:/tf_bin /var/tmp
-        docker cp -a $LOCAL_CACHE_CONTAINER:/tf_plugins_cache_dir /var/tmp
-        o=$(find /var/tmp/tf_bin /var/tmp/tf_plugins_cache_dir -type f | sort)
+        docker cp -a $LOCAL_CACHE_CONTAINER:/tf_plugin_cache_dir /var/tmp
+        o="$(find /var/tmp/tf_bin /var/tmp/tf_plugin_cache_dir -type f | sort)"
     else
-        o=$(find /tf_bin /tf_plugins_cache_dir -type f | sort)
+        o="$(find /tf_bin /tf_plugin_cache_dir -type f | sort)"
     fi
 
     if ! echo $o | grep -P "$exp" >/dev/null
     then
-        echo "ERROR $0: failure."
+        echo "ERROR $0: $test_name failed to find expected files."
         echo -e "... files in mounted vols:\n$o"
         rc=1
     else
-        echo "INFO $0:   (passed)"
+        echo "INFO $0: $test_name  (passed)"
     fi
 
     exit $rc
-)
+) || rc=1
 
 docker rm -f tf_cache_dirs 2>/dev/null
 

--- a/test.sh
+++ b/test.sh
@@ -1,42 +1,200 @@
 #!/bin/bash
 # vim: et sr sw=4 ts=4 smartindent:
 
-rc=0
+# When running tests locally, we need to mount some
+# dirs from the host for /tf_bin and /tf_plugins_cache_dir.
+#
+# In shippable, we use pre_ci_boot options to do the same.
+# and use a different mount arg for docker run.
+vol_str_for_caches() {
+    echo --volumes-from ${SHIPPABLE_CONTAINER_NAME:-$LOCAL_CACHE_CONTAINER}
+}
+
 img=opsgang/${IMG:-aws_terraform}:candidate
 _c=test_tf
+cmd="terraform init -input=false ; terraform apply -input=false -auto-approve"
 
-test_name="default-with-preinstalled-plugins"
-echo "INFO $0: test $test_name"
-echo "INFO $0: ... should download versions as necessary."
-var="export TF_VAR_ts=$test_name"
-cmd="$var ; terraform init && terraform apply -auto-approve"
-exp='Apply complete! Resources: 2 added, 0 changed, 0 destroyed.'
-docker rm -f $_c 2>/dev/null || true
-o=$(docker run --rm --name $_c -w /_test/default $img /bin/bash -c "$cmd")
-if [[ $? -ne 0 ]] || [[ ! $(echo "$o" | grep "$exp") ]]; then
-    echo "ERROR $0: failure"
-    echo "$o"
-    rc=1
-else
-    echo "INFO $0:   (passed)"
+# ... used in tests for cache dirs if not running in shippable.
+LOCAL_CACHE_CONTAINER=tf_cache_dirs
+tfcd=/var/tmp/tf_plugins_cache_dir
+tfbin=/var/tmp/tf_bin 
+if [[ -z "$SHIPPABLE_CONTAINER_NAME" ]]; then
+    docker run -d --name $LOCAL_CACHE_CONTAINER \
+        -v $tfcd:/tf_plugins_cache_dir \
+        -v $tfbin:/tf_bin \
+        alpine:3.7 /bin/sh -c 'while true; do sleep 1000; done'
 fi
 
-test_name="try-preinstalled-copy-pre-0.10.7"
-echo "INFO $0: test $test_name"
-echo "INFO $0: ... should download versions as necessary."
-var="export TF_VAR_ts=$test_name"
-cmd="$var ; terraform init && terraform apply -auto-approve"
-exp='Apply complete! Resources: 2 added, 0 changed, 0 destroyed.'
-v=0.10.6
-exp_v='Terraform v0\.10\.6$'
-docker rm -f $_c 2>/dev/null || true
-o=$(docker run --rm --name $_c -w /_test/default -e TERRAFORM_VERSION=$v $img /bin/bash -c "$cmd")
-if [[ $? -ne 0 ]] || [[ ! $(echo "$o" | grep "$exp") ]] || [[ ! $(echo "$o" | grep -P "$exp_v") ]] ; then
-    echo "ERROR $0: failure"
-    echo "$o"
-    rc=1
-else
-    echo "INFO $0:   (passed)"
-fi
+(
+    rc=0
+    test_name="default-with-preinstalled-plugins"
+    var="export TF_VAR_ts=$test_name"
+    exp='Apply complete! Resources: 2 added, 0 changed, 0 destroyed.'
+
+    echo "INFO $0: test $test_name"
+    echo "INFO $0: ... should use preloaded terraform version"
+
+    docker rm -f $_c 2>/dev/null || true
+    o=$(
+        docker run --rm --name $_c \
+            -w /_test/default \
+            $img /bin/bash -c "$var ; $cmd"
+    )
+    if [[ $? -ne 0 ]] || [[ ! $(echo "$o" | grep "$exp") ]]; then
+        echo "ERROR $0: failure"
+        echo "$o"
+        rc=1
+    else
+        echo "INFO $0:   (passed)"
+    fi
+    docker rm -f $_c 2>/dev/null || true
+    rm -rf _test/.terraform _test/default/.terraform
+) || rc=1
+
+(
+    rc=0
+    test_name="try-preinstalled-plugins-copy-pre-0.10.7"
+    var="export TF_VAR_ts=$test_name"
+    exp='Apply complete! Resources: 2 added, 0 changed, 0 destroyed.'
+    v=0.10.6
+    exp_v='Terraform v0\.10\.6$'
+
+    echo "INFO $0: test $test_name"
+    echo "INFO $0: ... using older terraform which needs plugins copied from cache"
+
+    docker rm -f $_c 2>/dev/null || true
+    o=$(
+        docker run --rm --name $_c \
+            -w /_test/default \
+            -e TERRAFORM_VERSION=$v \
+            $img /bin/bash -c "$var ; $cmd"
+    )
+    if [[ $? -ne 0 ]] || [[ ! $(echo "$o" | grep "$exp") ]] || [[ ! $(echo "$o" | grep -P "$exp_v") ]] ; then
+        echo "ERROR $0: failure"
+        echo "$o"
+        rc=1
+    else
+        echo "INFO $0:   (passed)"
+    fi
+    docker rm -f $_c 2>/dev/null || true
+    exit $rc
+) || rc=1
+
+(
+    rc=0
+    test_name="try-unprivileged-user"
+    var="export TF_VAR_ts=$test_name"
+    exp='Apply complete! Resources: 2 added, 0 changed, 0 destroyed.'
+
+    echo "INFO $0: test $test_name"
+    echo "INFO $0: ... trying non-root users with docker run --user "
+
+    for uid_gid in 501:501 666:999; do
+
+        docker rm -f $_c 2>/dev/null || true
+        o=$(
+            docker run --rm --name $_c \
+                -w /_test/unpriv \
+                --user $uid_gid \
+                $img /bin/bash -c "$var ; $cmd"
+        )
+        if [[ $? -ne 0 ]] || [[ ! $(echo "$o" | grep "$exp") ]]; then
+            echo "ERROR $0: failure"
+            echo "$o"
+            rc=1
+        else
+            echo "INFO $0:   (uid:gid[$uid_gid]: passed)"
+        fi
+        docker rm -f $_c 2>/dev/null || true
+    done
+    rm -rf _test/.terraform _test/default/.terraform
+
+    exit $rc
+) || rc=1
+
+(
+    rc=0
+    test_name="test-mounted-tf-dirs"
+    var="export TF_VAR_ts=$test_name"
+    exp='.*/tf_bin/terraform-[\d\.]+ .*/tf_plugins_cache_dir/linux_amd64/terraform-provider-null_v'
+
+    
+
+    echo "INFO $0: test $test_name"
+    echo "INFO $0: ... trying with mounted cache and tf_bin dirs"
+
+    docker rm -f $_c 2>/dev/null
+
+    docker run --rm --name $_c \
+        $(vol_str_for_caches) \
+        -w /_test/default \
+        $img /bin/bash -c "$var ; $cmd" || exit 1
+
+    docker rm -f $_c 2>/dev/null
+
+    if [[ -z "$SHIPPABLE_CONTAINER_NAME" ]]; then
+        rm -rf $tfcd
+        docker cp -a $LOCAL_CACHE_CONTAINER:/tf_bin /var/tmp
+        docker cp -a $LOCAL_CACHE_CONTAINER:/tf_plugins_cache_dir /var/tmp
+        o=$(find /var/tmp/tf_bin /var/tmp/tf_plugins_cache_dir -type f | sort)
+    else
+        o=$(find /tf_bin /tf_plugins_cache_dir -type f | sort)
+    fi
+
+    if ! echo $o | grep -P "$exp" >/dev/null
+    then
+        echo "ERROR $0: failure."
+        echo -e "... files in mounted vols:\n$o"
+        rc=1
+    else
+        echo "INFO $0:   (passed)"
+    fi
+
+    exit $rc
+)
+
+(
+    rc=0
+    test_name="test-mounted-tf-dirs-from-root-to-unpriv"
+    var="export TF_VAR_ts=$test_name"
+    exp='.*/tf_bin/terraform-[\d\.]+ .*/tf_plugins_cache_dir/linux_amd64/terraform-provider-null_v'
+
+    
+
+    echo "INFO $0: test $test_name"
+    echo "INFO $0: ... trying with mounted cache and tf_bin dirs as unpriv user with root-owned content"
+
+    docker rm -f $_c 2>/dev/null
+
+    docker run --rm --name $_c \
+        $(vol_str_for_caches) \
+        --user 501:501 \
+        -w /_test/unpriv \
+        $img /bin/bash -c "$var ; $cmd" || exit 1
+
+    docker rm -f $_c 2>/dev/null
+
+    if [[ -z "$SHIPPABLE_CONTAINER_NAME" ]]; then
+        rm -rf $tfcd
+        docker cp -a $LOCAL_CACHE_CONTAINER:/tf_bin /var/tmp
+        docker cp -a $LOCAL_CACHE_CONTAINER:/tf_plugins_cache_dir /var/tmp
+        o=$(find /var/tmp/tf_bin /var/tmp/tf_plugins_cache_dir -type f | sort)
+    else
+        o=$(find /tf_bin /tf_plugins_cache_dir -type f | sort)
+    fi
+
+    if ! echo $o | grep -P "$exp" >/dev/null
+    then
+        echo "ERROR $0: failure."
+        echo -e "... files in mounted vols:\n$o"
+        rc=1
+    else
+        echo "INFO $0:   (passed)"
+    fi
+
+    exit $rc
+)
+
+docker rm -f tf_cache_dirs 2>/dev/null
 
 exit $rc


### PR DESCRIPTION
An alternative answer to PR #8 

- allow running docker with --user uid:gid option  …
  so container can user a non-root uid e.g. for local development,
  you might want to use your own uid and gid.

- added better tests

- removed dependency on alpine build scripts repo.